### PR TITLE
✨ score, end screen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -315,6 +315,7 @@ name = "compat"
 version = "0.1.0"
 dependencies = [
  "ggez",
+ "net2",
  "rand 0.7.3",
  "serde",
  "serde_json",
@@ -1311,6 +1312,17 @@ dependencies = [
  "num-traits 0.2.15",
  "rand 0.6.5",
  "typenum",
+]
+
+[[package]]
+name = "net2"
+version = "0.2.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d0df99cfcd2530b2e694f6e17e7f37b8e26bb23983ac530c0c97408837c631"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/src/app_state.rs
+++ b/src/app_state.rs
@@ -4,8 +4,9 @@ use ggez::input::keyboard::{self, KeyCode}; // 키보드 모듈
 use ggez::{Context, GameResult}; // 게임 모듈(실행환경 저장 및 결과 반환)
 
 use crate::constants::StateTransition;
-use crate::title_state::TitleState;
+use crate::end_state::EndState;
 use crate::game_state::GameState;
+use crate::title_state::TitleState;
 
 // AppState는 게임의 현재 State를 인자로 가지는 ENUM을 갖고, ENUM의 값에 해당하는 스테이트의 이벤트핸들러 함수를 수행합니다.
 // 즉 동작에 따라 씬을 전환하는 역할을 수행하는, event::run에서 사용될 최상위 스테이트입니다.
@@ -30,14 +31,17 @@ impl AppState {
     //각 State의 Stage Transition을 인자로 받아서, 현재 페이지(State)를 인자로 받은 스테이트로 변경하는 함수
     pub fn change_state(&mut self, ctx: &mut Context, state_transition: StateTransition) {
         match state_transition {
-            StateTransition::ToTitle => {
-                self.current_state = CurrentState::Title(TitleState::new(ctx));
-            }
             StateTransition::Solo => {
                 self.current_state = CurrentState::Game(GameState::new(ctx, 0));
             }
             StateTransition::Multi => {
                 self.current_state = CurrentState::Game(GameState::new(ctx, 1));
+            }
+            StateTransition::P1Win => {
+                self.current_state = CurrentState::End(EndState::new(ctx, 1));
+            }
+            StateTransition::P2Win => {
+                self.current_state = CurrentState::End(EndState::new(ctx, 2));
             }
             _ => {}
         }
@@ -48,6 +52,7 @@ impl AppState {
 pub enum CurrentState {
     Title(TitleState),
     Game(GameState),
+    End(EndState),
 }
 
 impl event::EventHandler for AppState {
@@ -67,7 +72,9 @@ impl event::EventHandler for AppState {
             CurrentState::Game(game_state) => {
                 // game_state를 사용하여 마우스 클릭 로직을 수행합니다.
             }
-
+            CurrentState::End(end_state) => {
+                // end_state를 사용하여 마우스 클릭 로직을 수행합니다.
+            }
         };
     }
 
@@ -76,18 +83,21 @@ impl event::EventHandler for AppState {
         match &mut self.current_state {
             CurrentState::Title(title_state) => {
                 // title_state를 사용하여 업데이트 로직을 수행합니다.
-                title_state.update(ctx).unwrap();
             }
             CurrentState::Game(game_state) => {
                 // game_state를 사용하여 업데이트 로직을 수행합니다.
                 game_state.update(ctx).unwrap();
+            }
+            CurrentState::End(end_state) => {
+                // end_state를 사용하여 업데이트 로직을 수행합니다.
             }
         }
 
         //현재 스테이트의, 스테이트 변경 요청을 체크 후 가져오기
         let state_transition = match &mut self.current_state {
             CurrentState::Title(title_state) => title_state.state_transition,
-            CurrentState::Game(game_state) => StateTransition::None,
+            CurrentState::Game(game_state) => game_state.state_transition,
+            CurrentState::End(end_state) => StateTransition::None,
         };
 
         //스테이트 변경 요청에 따라 스테이트를 변경
@@ -106,6 +116,10 @@ impl event::EventHandler for AppState {
             CurrentState::Game(game_state) => {
                 // game_state를 사용하여 렌더링 로직을 수행합니다.
                 game_state.draw(ctx).unwrap();
+            }
+            CurrentState::End(end_state) => {
+                // end_state를 사용하여 업데이트 로직을 수행합니다.
+                end_state.draw(ctx).unwrap();
             }
         }
         Ok(())

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -18,8 +18,8 @@ pub const SERVER_ADDR: &str = "127.0.0.1:8080"; // 서버의 주소
 #[derive(Clone, Copy)]
 pub enum StateTransition {
     None,
-    ToTitle,
-    ToMain,
     Multi,
     Solo,
+    P1Win,
+    P2Win,
 }

--- a/src/end_state.rs
+++ b/src/end_state.rs
@@ -1,0 +1,49 @@
+use ggez::event;
+use ggez::graphics; // 그래픽 모듈
+use ggez::input::keyboard::{self, KeyCode}; // 키보드 모듈
+use ggez::nalgebra as na; // 벡터, 행렬 등의 수학 연산 모듈
+use ggez::{Context, GameResult};
+
+//점수에 따라 승자를 표시
+
+pub struct EndState {
+    win_player: i32, //승자 번호
+}
+
+impl EndState {
+    pub fn new(ctx: &mut Context, win_player: i32) -> Self {
+        EndState { win_player }
+    }
+}
+impl event::EventHandler for EndState {
+    fn update(&mut self, ctx: &mut Context) -> GameResult {
+        Ok(())
+    }
+    fn draw(&mut self, ctx: &mut Context) -> GameResult {
+        graphics::clear(ctx, graphics::BLACK);
+
+        // 승자 텍스트 생성
+        let win_text = format!("Player {} Win!", self.win_player);
+
+        // 텍스트 객체 생성
+        let win_text_obj = graphics::Text::new(win_text);
+
+        // 화면 크기 구하기
+        let screen_size = graphics::drawable_size(ctx);
+
+        // 텍스트의 크기 구하기
+        let text_size = win_text_obj.dimensions(ctx);
+
+        // 텍스트를 화면 중앙에 위치시키기 위한 좌표 계산
+        let position = na::Point2::new(
+            (screen_size.0 - text_size.0 as f32) / 2.0,
+            (screen_size.1 - text_size.1 as f32) / 2.0,
+        );
+
+        // 텍스트 그리기
+        graphics::draw(ctx, &win_text_obj, (position, 0.0, graphics::WHITE))?;
+
+        graphics::present(ctx)?;
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,10 +18,11 @@ use std::thread;
 
 mod app_state;
 mod constants; // 상수를 관리하는 모듈입니다.
+mod end_state;
+mod game_state;
 mod server; // 서버를 관리하는 모듈입니다.
 mod state_func; // move_racket, randomize_vec 함수를 관리하는 모듈입니다.
 mod title_state;
-mod game_state;
 
 use app_state::AppState;
 use constants::*;

--- a/src/title_state.rs
+++ b/src/title_state.rs
@@ -99,10 +99,10 @@ impl event::EventHandler for TitleState {
 
         //설정한 사각형 좌표에 마우스 클릭 좌표가 겹치면 게임 페이지 전환.
         if single_button_rect.contains(point) {
-            self.state_transition = StateTransition::Solo; //현 시점에서는 싱글 플레이 버튼을 누를 시, 호스트 스테이트로 전환하도록 임시로 설정
+            self.state_transition = StateTransition::Solo;
         }
         if multi_button_rect.contains(point) {
-            self.state_transition = StateTransition::Multi; //현 시점에서는 멀티 플레이 버튼을 누를 시, 플레이어 스테이트로 전환하도록 임시로 설정
+            self.state_transition = StateTransition::Multi;
         }
     }
 


### PR DESCRIPTION
GameState에 게임 도중에 출력되는 스코어 보드를 추가했습니다.
싱글 플레이 실행 시 화면 표시가 상태 업데이트보다 늦게 되는 오류가 있어서 (화면이 표시되기도 전에 점수가 1:0이 되는 오류)
임시로 타이머를 이용해 해결했습니다.
또 일단은 Solo 상태에 해당 기능을 넣어놔서 솔로 플레이 시만 스코어가 동작합니다. (멀티 완성후 변경 필요)

점수에 따라 승자를 출력하는 마지막 화면인 EndState를 추가했습니다.
StateTransition에 따라 한 명의 점수가 5점이 되면 화면이 EndState로 넘어갑니다.
표시를 위해 AppState와 StateTransition을 변경했습니다.
